### PR TITLE
Use accept attribute to drive File Input Display Controller validation

### DIFF
--- a/app/helpers/bulma/form_helper.rb
+++ b/app/helpers/bulma/form_helper.rb
@@ -129,9 +129,10 @@ module Bulma
     def file_field(object_name, method, options = {})
       append_classes_to_options(options, "file-input")
       append_data_attributes_to_options(options, bulma__file_input_display_target: "fileInput", action: "bulma--file-input-display#show")
+      accepted_file_types = options.fetch(:accept, "").split(",").map(&:strip)
 
       # [File Upload](https://bulma.io/documentation/form/file/)
-      tag.div(class: "file is-boxed", data: { controller: "bulma--file-input-display" }) do
+      tag.div(class: "file is-boxed", data: { controller: "bulma--file-input-display", bulma__file_input_display_accepted_file_types_value: accepted_file_types }) do
         tag.label(class: "file-label") do
           concat super
           concat(tag.span(class: "file-cta") do

--- a/test/helpers/bulma/form_helper_test.rb
+++ b/test/helpers/bulma/form_helper_test.rb
@@ -199,13 +199,13 @@ module Bulma
 
     test "file_field" do
       result = I18n.stub :translate, "Avatar", [ :avatar, { scope: [ "helpers", "label", :user ], default: "Avatar" } ] do
-        file_field(:user, :avatar, object: @user)
+        file_field(:user, :avatar, object: @user, accept: "image/png,image/jpeg")
       end
 
       expected = <<~HTML
-        <div class="file is-boxed" data-controller="bulma--file-input-display">
+        <div class="file is-boxed" data-controller="bulma--file-input-display" data-bulma--file-input-display-accepted-file-types-value="[&quot;image/png&quot;,&quot;image/jpeg&quot;]">
           <label class="file-label">
-            <input class="file-input" type="file" name="user[avatar]" id="user_avatar"
+            <input accept="image/png,image/jpeg" class="file-input" type="file" name="user[avatar]" id="user_avatar"
                   data-bulma--file-input-display-target="fileInput"
                   data-action="bulma--file-input-display#show" />
             <span class="file-cta">


### PR DESCRIPTION
The accept attribute already specifies the file types, so no stimulus value is needed. This also enhances the logic to handle mime types, too.

Resolves #4 